### PR TITLE
swap Picasso / Pitt pics in README for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ onto a night-time photograph of the Stanford campus:
 The algorithm allows the user to trade-off the relative weight of the style and content reconstruction terms,
 as shown in this example where we port the style of [Picasso's 1907 self-portrait](http://www.wikiart.org/en/pablo-picasso/self-portrait-1907) onto Brad Pitt:
 
-<img src="https://raw.githubusercontent.com/jcjohnson/neural-style/master/examples/inputs/brad_pitt.jpg" height="220px">
 <img src="https://raw.githubusercontent.com/jcjohnson/neural-style/master/examples/inputs/picasso_selfport1907.jpg" height="220px">
+<img src="https://raw.githubusercontent.com/jcjohnson/neural-style/master/examples/inputs/brad_pitt.jpg" height="220px">
 
 <img src="https://raw.githubusercontent.com/jcjohnson/neural-style/master/examples/outputs/pitt_picasso_style_1_content_8.png" height="220px">
 <img src="https://raw.githubusercontent.com/jcjohnson/neural-style/master/examples/outputs/pitt_picasso_style_2_content_8.png" height="220px">


### PR DESCRIPTION
OK, I fully admit that this might be the most petty
pull request imaginable. But I think the README
reads better if the two examples match in ordering,
and so I'd like to propose the convention where
style precedes content since it loosely reflects
feedforward net order.