### PR TITLE
assign style/content layers by name

### DIFF
--- a/loadcaffe_wrapper.lua
+++ b/loadcaffe_wrapper.lua
@@ -55,6 +55,7 @@ local function loadcaffe_load(prototxt_name, binary_name, backend)
   local net = nn.Sequential()
   local list_modules = model
   for i,item in ipairs(list_modules) do
+    item[2].name = item[1]
     if item[2].weight then
       local w = torch.FloatTensor()
       local bias = torch.FloatTensor()

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -73,8 +73,8 @@ local function main(params)
   end
   
   -- Hardcode these for now
-  local content_layers = {23}
-  local style_layers = {2, 7, 12, 21, 30}
+  local content_layers = {'relu4_2'}
+  local style_layers = {'relu1_1', 'relu2_1', 'relu3_1', 'relu4_1', 'relu5_1'}
   local style_layer_weights = {1e0, 1e0, 1e0, 1e0, 1e0}
 
   -- Set up the network, inserting style and content loss modules
@@ -91,6 +91,7 @@ local function main(params)
   for i = 1, #cnn do
     if next_content_idx <= #content_layers or next_style_idx <= #style_layers then
       local layer = cnn:get(i)
+      local name = layer.name
       local layer_type = torch.type(layer)
       local is_pooling = (layer_type == 'cudnn.SpatialMaxPooling' or layer_type == 'nn.SpatialMaxPooling')
       if is_pooling and params.pooling == 'avg' then
@@ -105,7 +106,8 @@ local function main(params)
       else
         net:add(layer)
       end
-      if i == content_layers[next_content_idx] then
+      if name == content_layers[next_content_idx] then
+        print("Setting up content layer", i, ":", layer.name)
         local target = net:forward(content_image_caffe):clone()
         local norm = params.normalize_gradients
         local loss_module = nn.ContentLoss(params.content_weight, target, norm):float()
@@ -116,7 +118,8 @@ local function main(params)
         table.insert(content_losses, loss_module)
         next_content_idx = next_content_idx + 1
       end
-      if i == style_layers[next_style_idx] then
+      if name == style_layers[next_style_idx] then
+        print("Setting up style layer  ", i, ":", layer.name)
         local gram = GramMatrix():float()
         if params.gpu >= 0 then
           gram = gram:cuda()

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -39,6 +39,8 @@ cmd:option('-proto_file', 'models/VGG_ILSVRC_19_layers_deploy.prototxt')
 cmd:option('-model_file', 'models/VGG_ILSVRC_19_layers.caffemodel')
 cmd:option('-backend', 'nn', 'nn|cudnn')
 
+cmd:option('-content_layers', 'relu4_2', 'layers for content')
+cmd:option('-style_layers', 'relu1_1,relu2_1,relu3_1,relu4_1,relu5_1', 'layers for style')
 
 local function main(params)
   if params.gpu >= 0 then
@@ -72,10 +74,9 @@ local function main(params)
     style_image_caffe = style_image_caffe:cuda()
   end
   
-  -- Hardcode these for now
-  local content_layers = {'relu4_2'}
-  local style_layers = {'relu1_1', 'relu2_1', 'relu3_1', 'relu4_1', 'relu5_1'}
-  local style_layer_weights = {1e0, 1e0, 1e0, 1e0, 1e0}
+  local content_layers = params.content_layers:split(",")
+  local style_layers = params.style_layers:split(",")
+  local style_layer_weights = {1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0, 1e0}
 
   -- Set up the network, inserting style and content loss modules
   local content_losses, style_losses = {}, {}


### PR DESCRIPTION
When loading layers save the name. Later when choosing style and content layers, lookup by name instead of index. Note that the overall behavior with this commit is unchanged.

Also note that all style/content layers are currently relu layers and not conv layers - is this a bug? You
can confirm that the actual indices are unchanged with the diagnostic output:

```bash
Setting up style layer          2       :       relu1_1
Setting up style layer          7       :       relu2_1
Setting up style layer          12      :       relu3_1
Setting up style layer          21      :       relu4_1
Setting up content layer        23      :       relu4_2
Setting up style layer          30      :       relu5_1
```

I had started to prepare a followup commit changing hardcoded layers in 'neural_style.lua` to:

```lua
local content_layers = {'conv4_2'}
local style_layers = {'conv1_1', 'conv2_1', 'conv3_1', 'conv4_1', 'conv5_1'}
```

but in my testing I couldn't easily find hyper parameters that gave sensible output so thought I would ask first if this is an off my one bug (the conv layers are exactly -1 of the relu ones) or if this was intended behavior.