### PR TITLE
build_filename: Find last '.' instead of first.

### DIFF
--- a/neural_style.lua
+++ b/neural_style.lua
@@ -220,7 +220,7 @@ end
   
 
 function build_filename(output_image, iteration)
-  local idx = string.find(output_image, '%.')
+  local idx = string.find(output_image, '%.[^.]*$')
   local basename = string.sub(output_image, 1, idx - 1)
   local ext = string.sub(output_image, idx)
   return string.format('%s_%d%s', basename, iteration, ext)


### PR DESCRIPTION
Not a perfect `splitext` implementation, but this fixes issues when `output_image` starts with `./` or contains a `.`