### PR TITLE
reduce training time by 25% time; save ~10% memory

### DIFF
--- a/neural_style.lua
+++ b/neural_style.lua
@@ -58,6 +58,7 @@ local function main(params)
 
   if params.backend == 'cudnn' then
     require 'cudnn'
+    cudnn.SpatialConvolution.accGradParameters = nn.SpatialConvolutionMM.accGradParameters -- ie: nop
   end
   
   local cnn = loadcaffe_wrap.load(params.proto_file, params.model_file, params.backend):float()


### PR DESCRIPTION
Hi Justin,

This removes update of weights in the convolution layers.  Per my understanding this is not needed?  By removing this, we save:
- 25% training time :-P
- about ~8% memory

(Tested on image size 200, over 50 iterations)
