### PR TITLE
add -seed option, for repeatable runs

### DIFF
--- a/neural_style.lua
+++ b/neural_style.lua
@@ -39,6 +39,7 @@ cmd:option('-pooling', 'max', 'max|avg')
 cmd:option('-proto_file', 'models/VGG_ILSVRC_19_layers_deploy.prototxt')
 cmd:option('-model_file', 'models/VGG_ILSVRC_19_layers.caffemodel')
 cmd:option('-backend', 'nn', 'nn|cudnn')
+cmd:option('-seed', -1)
 
 cmd:option('-content_layers', 'relu4_2', 'layers for content')
 cmd:option('-style_layers', 'relu1_1,relu2_1,relu3_1,relu4_1,relu5_1', 'layers for style')
@@ -185,6 +186,9 @@ local function main(params)
   collectgarbage()
   
   -- Initialize the image
+  if params.seed >= 0 then
+    torch.manualSeed(params.seed)
+  end
   local img = nil
   if params.init == 'random' then
     img = torch.randn(content_image:size()):float():mul(0.001)


### PR DESCRIPTION
Hi Justin,

This adds `-seed `option, so can get repeatable results.  Try running twice, with same `-seed`, eg `-seed 123`, and you should get the same output image each time.

This is good for correctness checking for example.
