### PR TITLE
Resume downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 out*.png
 *.png
+models/
+!models/download_models.sh

--- a/models/download_models.sh
+++ b/models/download_models.sh
@@ -1,5 +1,5 @@
 cd models
-wget https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/bb2b4fe0a9bb0669211cf3d0bc949dfdda173e9e/VGG_ILSVRC_19_layers_deploy.prototxt
-wget --no-check-certificate https://bethgelab.org/media/uploads/deeptextures/vgg_normalised.caffemodel
-wget http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel
+wget -c https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/bb2b4fe0a9bb0669211cf3d0bc949dfdda173e9e/VGG_ILSVRC_19_layers_deploy.prototxt
+wget -c --no-check-certificate https://bethgelab.org/media/uploads/deeptextures/vgg_normalised.caffemodel
+wget -c http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel
 cd ..


### PR DESCRIPTION
During model download, my Internet connection was cut. On re-running `models/download_models.sh`, I noticed that:
* Files that were downloaded fully got downloaded again.
* Files that were incomplete got downloaded from scratch.

Adding the `-c` flag to `wget` works around each of these issues:
* If a file has been downloaded fully, `wget` figures that out.
* If a file needs to be resumed, `wget` resumes at the proper location.

I also noticed that downloaded files weren't ignored by `git`, so I added the `models` directory (excepting the download script) to `.gitignore`
