### PR TITLE
Add support for specifying a destination directory

### DIFF
--- a/neural_style.lua
+++ b/neural_style.lua
@@ -304,7 +304,8 @@ end
 function build_filename(output_image, iteration)
   local ext = paths.extname(output_image)
   local basename = paths.basename(output_image, ext)
-  return string.format('%s_%d.%s', basename, iteration, ext)
+  local dirname = paths.dirname(output_image)
+  return string.format('%s/%s_%d.%s', dirname, basename, iteration, ext)
 end
 
 


### PR DESCRIPTION
Allow -output_image to include a full path instead of only relative.