### PR TITLE
Apply filter in docker container, supporting GPU

### DIFF
--- a/nut.yml
+++ b/nut.yml
@@ -1,0 +1,19 @@
+syntax_version: "7"
+project_name: neural-style
+docker_image: matthieudelaro/cuda-torch-plus
+container_working_directory: /opt/style
+volumes:
+  main:
+    host_path: .
+    container_path: /opt/style
+macros:
+  setup:
+    usage: download model
+    actions:
+    - sh ./models/download_models.sh
+  run:
+    usage: run the neural network in the container, on GPU
+    enable_nvidia_devices: true
+    actions:
+    - export iterations=1000
+    - time th neural_style.lua -num_iterations $iterations -seed 123 -style_image style_image.jpg -content_image content_image.jpg -output_image "output_image_`date '+%Y-%m-%d_%Hh%Mmin%S'`.png"


### PR DESCRIPTION
I added the file **nut.yml**, so that generating images in a docker image, on GPU, can be as easy as running the command `nut run` in the repo. This address issues/PR such as https://github.com/jcjohnson/neural-style/pull/151

[Nut](https://github.com/matthieudelaro/nut) is a tool to run commands in a docker container, while supporting nvidia devices, volumes, etc. Here, **nut.yml** declares the following settings:
- use docker image `matthieudelaro/cuda-torch-plus`
- mount the current directory as `/opt/style`
- mount nvidia GPUs in the container
- run the neural network with 1000 iterations, computing a new image from style_image.jpg and content_image.jpg

Note that Docker supports GPUs on Linux only, and that Nut relies on [nvidia-docker-plugin](https://github.com/NVIDIA/nvidia-docker/wiki/Using-nvidia-docker-plugin) ([details](https://github.com/matthieudelaro/nut#support-for-nvidia-docker)).

In case GPUs are not available, nut will display a warning message and run the neural network.

To run the neural network with a custom command, you can use `--exec` flag. For example:
```terminal
nut --exec='th neural_style.lua -style_image examples/inputs/picasso_selfport1907.jpg -content_image examples/inputs/brad_pitt.jpg -output_image profile.png -model_file models/nin_imagenet_conv.caffemodel -proto_file models/train_val.prototxt -gpu 0 -backend clnn -num_iterations 1000 -seed 123 -content_layers relu0,relu3,relu7,relu12 -style_layers relu0,relu3,relu7,relu12 -content_weight 10 -style_weight 1000 -image_size 512 -optimizer adam'
```