### PR TITLE
 Option to initialize image with arbitrary other image

### DIFF
--- a/neural_style.lua
+++ b/neural_style.lua
@@ -249,7 +249,10 @@ local function main(params)
   elseif params.init == 'image' then
     img = content_image_caffe:clone():float()
   else
-    error('Invalid init type')
+    -- Read other init arguments as path to initial image
+    local alternate_initial_image = image.load(params.alternate_initial_image, 3)
+    alternate_initial_image = image.scale(alternate_initial_image, params.image_size, 'bilinear')
+    img = preprocess(alternate_initial_image):float()
   end
   if params.gpu >= 0 then
     if params.backend ~= 'clnn' then

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -250,7 +250,7 @@ local function main(params)
     img = content_image_caffe:clone():float()
   else
     -- Read other init arguments as path to initial image
-    local alternate_initial_image = image.load(params.alternate_initial_image, 3)
+    local alternate_initial_image = image.load(params.init, 3)
     alternate_initial_image = image.scale(alternate_initial_image, params.image_size, 'bilinear')
     img = preprocess(alternate_initial_image):float()
   end


### PR DESCRIPTION
Main hypothesized use: Batch jobs of individual frames of animation, priming each frame with the prior frame's output for increased consistency across time. Appears to be effective for that purpose. I have not yet tested initializing with irrelevant other images, as I'm currently processing the animation I made this change for.

This is the first pull request I've done - apologies if I've missed something. Also first time I've touched lua, but this was a simple addition.
