### PR TITLE
Helper python script (w/ style_layer_weights)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ When using multiple style images, you can control the degree to which they are b
 It is possible to adjust the relative weights of style layers giving a comma separated list of multipliers (actual style weight of each layer will then be style_layer_weight * style_weight.
 
 ```
-th neural_style.lua -gpu -1 style_layer_weights 1,1,0.1,2,15 
+th neural_style.lua -gpu -1 style_layer_weights 1,1,0.1,2,15
 ```
 
 
@@ -246,7 +246,7 @@ If you are running on a GPU, you can also try running with `-backend cudnn` to r
 
 **Solution:** Update `torch.paths` package to the latest version: `luarocks install paths`
 
-**Problem:** NIN Imagenet model is not giving good results. 
+**Problem:** NIN Imagenet model is not giving good results.
 
 **Solution:** Make sure the correct `-proto_file` is selected. Also make sure the correct parameters for `-content_layers` and `-style_layers` are set. (See OpenCL usage example above.)
 
@@ -265,7 +265,7 @@ These give good results, but can both use a lot of memory. You can reduce memory
   This should work in both CPU and GPU modes.
 * **Reduce image size**: If the above tricks are not enough, you can reduce the size of the generated image;
   pass the flag `-image_size 256` to generate an image at half the default size.
-  
+
 With the default settings, `neural-style` uses about 3.5GB of GPU memory on my system;
 switching to ADAM and cuDNN reduces the GPU memory footprint to about 1GB.
 
@@ -278,7 +278,7 @@ Here are some times for running 500 iterations with `-image_size=512` on a Maxwe
 * `-backend cudnn -cudnn_autotune -optimizer lbfgs`: 58 seconds
 * `-backend cudnn -cudnn_autotune -optimizer adam`: 44 seconds
 * `-backend clnn -optimizer lbfgs`: 169 seconds
-* `-backend clnn -optimizer adam`: 106 seconds 
+* `-backend clnn -optimizer adam`: 106 seconds
 
 Here are the same benchmarks on a Pascal Titan X with cuDNN 5.0 on CUDA 8.0 RC:
 * `-backend nn -optimizer lbfgs`: 43 seconds
@@ -300,7 +300,7 @@ for your setup in order to achieve maximal resolution.
 
 We can achieve very high quality results at high resolution by combining multi-GPU processing with multiscale
 generation as described in the paper
-<a href="https://arxiv.org/abs/1611.07865">**Controlling Perceptual Factors in Neural Style Transfer**</a> by Leon A. Gatys, 
+<a href="https://arxiv.org/abs/1611.07865">**Controlling Perceptual Factors in Neural Style Transfer**</a> by Leon A. Gatys,
 Alexander S. Ecker, Matthias Bethge, Aaron Hertzmann and Eli Shechtman.
 
 Here is a 3620 x 1905 image generated on a server with four Pascal Titan X GPUs:
@@ -315,6 +315,21 @@ Images are initialized with white noise and optimized using L-BFGS.
 We perform style reconstructions using the `conv1_1`, `conv2_1`, `conv3_1`, `conv4_1`, and `conv5_1` layers
 and content reconstructions using the `conv4_2` layer. As in the paper, the five style reconstruction losses have
 equal weights.
+
+## Helper script
+`run_neural_style.py` (tested on Python 3.5.2) script can be used to automate output file path and name generation like this:
+
+`python3 run_neural_style.py -style_image styles/style22_750.jpg -content_image input/sample1.jpg -optimizer adam -init image -output_path output -backend cudnn -style_weight 800 -content_weight 200 -style_scale 1.8 -learning_rate 3 -image_size 300 -tv_weight 0.001 -seed 150 -num_iterations 500` will create a `output/style22_750/sample1` folder and the result file name will be `i500.0cw200_sw600_adam_lr3_sc1.8_tv0.001.jpg`
+
+The arguments mostly follow the neural-style with some exceptions:
+
+* `-style_blend_weights`: not supported yet
+* `-output_path`: Used instead of `-output_image`. Path for the output folder. Default is current folder.
+* `-input_file_as_folder`: Uses input file
+* `-style_as_folder` and `-no-style_as_folder`: Use/not use style name as an additional folder for output images. Default is `-style_as_folder`
+* `-input_file_as_folder` and `-no-input_file_as_folder`: Use/not use input image file name as an additional folder for output images. Default is `-input_file_as_folder`
+* `-style_layer_weights`: not supported yet
+* `-time_markers`: add time marker (Ymd_HMS) to the end of the output file name
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ When using multiple style images, you can control the degree to which they are b
 <img src="https://raw.githubusercontent.com/jcjohnson/neural-style/master/examples/outputs/golden_gate_starry_scream_5_5.png" height="175px">
 <img src="https://raw.githubusercontent.com/jcjohnson/neural-style/master/examples/outputs/golden_gate_starry_scream_7_3.png" height="175px">
 
+### Relative style layer weights
+
+It is possible to adjust the relative weights of style layers giving a comma separated list of multipliers (actual style weight of each layer will then be style_layer_weight * style_weight.
+
+```
+th neural_style.lua -gpu -1 style_layer_weights 1,1,0.1,2,15 
+```
+
+
 
 ### Transfer style but not color
 If you add the flag `-original_colors 1` then the output image will retain the colors of the original image;
@@ -188,6 +197,8 @@ path or a full absolute path.
   Default is `relu4_2`.
 * `-style_layers`: Comma-separated list of layer names to use for style reconstruction.
   Default is `relu1_1,relu2_1,relu3_1,relu4_1,relu5_1`.
+* `-style_layer_weights`: Comma-separated list of weight multipliers to adjust relative weight of style layers.
+  If parameter is not given, all style layers will have relative weight = 1.
 
 **Other options**:
 * `-style_scale`: Scale at which to extract features from the style image. Default is 1.0.

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -47,6 +47,7 @@ cmd:option('-seed', -1)
 
 cmd:option('-content_layers', 'relu4_2', 'layers for content')
 cmd:option('-style_layers', 'relu1_1,relu2_1,relu3_1,relu4_1,relu5_1', 'layers for style')
+cmd:option('-style_layer_weights', 'nil')
 
 
 local function main(params)
@@ -70,6 +71,7 @@ local function main(params)
     table.insert(style_images_caffe, img_caffe)
   end
 
+<<<<<<< HEAD
   local init_image = nil
   if params.init_image ~= '' then
     init_image = image.load(params.init_image, 3)
@@ -77,6 +79,10 @@ local function main(params)
     init_image = image.scale(init_image, W, H, 'bilinear')
     init_image = preprocess(init_image):float()
   end
+=======
+
+ 
+>>>>>>> b54479be3d9a810d5f6ccfc4f28324fad6233ea8
 
   -- Handle style blending weights for multiple style inputs
   local style_blend_weights = nil
@@ -103,6 +109,17 @@ local function main(params)
 
   local content_layers = params.content_layers:split(",")
   local style_layers = params.style_layers:split(",")
+
+  local style_layer_weights = {}
+    if params.style_layer_weights == 'nil' then
+      for i = 1, #style_layers do
+       table.insert(style_layer_weights, 1)
+      end
+   else
+     style_layer_weights = params.style_layer_weights:split(',')
+     assert(#style_layer_weights == #style_layers,
+      '-style_layer_weights and -style_layers must have the same number of elements')
+   end 
 
   -- Set up the network, inserting style and content loss modules
   local content_losses, style_losses = {}, {}
@@ -140,7 +157,18 @@ local function main(params)
       if name == style_layers[next_style_idx] then
         print("Setting up style layer  ", i, ":", layer.name)
         local norm = params.normalize_gradients
+<<<<<<< HEAD
         local loss_module = nn.StyleLoss(params.style_weight, norm):type(dtype)
+=======
+        local loss_module = nn.StyleLoss(params.style_weight * tonumber(style_layer_weights[next_style_idx]), target, norm):float()
+        if params.gpu >= 0 then
+          if params.backend ~= 'clnn' then
+            loss_module:cuda()
+          else
+            loss_module:cl()
+          end
+        end
+>>>>>>> b54479be3d9a810d5f6ccfc4f28324fad6233ea8
         net:add(loss_module)
         table.insert(style_losses, loss_module)
         next_style_idx = next_style_idx + 1

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -71,7 +71,6 @@ local function main(params)
     table.insert(style_images_caffe, img_caffe)
   end
 
-<<<<<<< HEAD
   local init_image = nil
   if params.init_image ~= '' then
     init_image = image.load(params.init_image, 3)
@@ -79,10 +78,6 @@ local function main(params)
     init_image = image.scale(init_image, W, H, 'bilinear')
     init_image = preprocess(init_image):float()
   end
-=======
-
- 
->>>>>>> b54479be3d9a810d5f6ccfc4f28324fad6233ea8
 
   -- Handle style blending weights for multiple style inputs
   local style_blend_weights = nil
@@ -119,7 +114,7 @@ local function main(params)
      style_layer_weights = params.style_layer_weights:split(',')
      assert(#style_layer_weights == #style_layers,
       '-style_layer_weights and -style_layers must have the same number of elements')
-   end 
+   end
 
   -- Set up the network, inserting style and content loss modules
   local content_losses, style_losses = {}, {}
@@ -157,18 +152,7 @@ local function main(params)
       if name == style_layers[next_style_idx] then
         print("Setting up style layer  ", i, ":", layer.name)
         local norm = params.normalize_gradients
-<<<<<<< HEAD
-        local loss_module = nn.StyleLoss(params.style_weight, norm):type(dtype)
-=======
-        local loss_module = nn.StyleLoss(params.style_weight * tonumber(style_layer_weights[next_style_idx]), target, norm):float()
-        if params.gpu >= 0 then
-          if params.backend ~= 'clnn' then
-            loss_module:cuda()
-          else
-            loss_module:cl()
-          end
-        end
->>>>>>> b54479be3d9a810d5f6ccfc4f28324fad6233ea8
+        local loss_module = nn.StyleLoss(params.style_weight * tonumber(style_layer_weights[next_style_idx]), target, norm):type(dtype)
         net:add(loss_module)
         table.insert(style_losses, loss_module)
         next_style_idx = next_style_idx + 1

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -155,7 +155,7 @@ lr{learning_rate}_sc{style_scale}_tv{tv_weight}'.format(
     style_scale=opts.style_scale,
     init=opts.init,
     style_image=expanduser(opts.style_image),
-    content_image=opts.content_image,
+    content_image=input_file,
     image_size=opts.image_size,
     output_image=out_file_path,
     content_weight=opts.content_weight,
@@ -226,7 +226,7 @@ def main():
         i = 1
         for input_filename in input_files:
             print('Input file is {0}'.format(input_filename))
-            run_on_file(opts, input_filename)
+            run_on_file(opts, join(input_path, input_filename))
             printProgress(i, count, prefix='Progress:',
                           suffix='Complete', barLength=100)
             i += 1

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -206,7 +206,7 @@ def printProgress(iteration, total, prefix='', suffix='', decimals=1, barLength=
     filledLength = int(round(barLength * iteration / float(total)))
     bar = '█' * filledLength + '-' * (barLength - filledLength)
     text = '\r%s |%s| %s%s %s' % (prefix, bar, percent, '%', suffix)
-    sys.stdout.write(text.encode('utf-8')),
+    sys.stdout.write(text),
     if iteration == total:
         sys.stdout.write('\n')
     sys.stdout.flush()
@@ -226,7 +226,7 @@ def main():
         count = len(input_files)
         i = 1
         for input_filename in input_files:
-            print('Input file is {0}'.format(input_filename))
+            print('\nInput file is {0}'.format(input_filename))
             run_on_file(opts, join(input_path, input_filename))
             printProgress(i, count, prefix='Progress:',
                           suffix='Complete', barLength=100)

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -10,6 +10,7 @@ RUN_SCRIPT_NAME = "neural_style.lua"
 
 def build_parser():
     parser = ArgumentParser()
+
     # Basic options
     parser.add_argument('-style_image', type=str,
                         default='examples/inputs/seated-nude.jpg',
@@ -59,7 +60,7 @@ def build_parser():
                         choices=['random', 'image'])
     parser.add_argument('-optimizer', default='lbfgs', dest='optimizer',
                         choices=['lbfgs', 'adam'])
-    parser.add_argument('-learning_rate', default=5, type=float,
+    parser.add_argument('-learning_rate', default=10, type=float,
                         dest='learning_rate')
 
     # Output options

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 import os, sys, subprocess
 from datetime import datetime
 from argparse import ArgumentParser
@@ -118,7 +119,7 @@ def run_on_file(opts, input_file):
     out_file_name = '{style_image}_{content_image}_cw{content_weight}_sw{style_weight}_\
 lr{learning_rate}_sc{style_scale}_tv{tv_weight}'.format(
     style_image=splitext(basename(opts.style_image))[0],
-    content_image=splitext(basename(opts.content_image))[0],
+    content_image=splitext(basename(input_file))[0],
     content_weight='%g'%(opts.content_weight),
     style_weight='%g'%(opts.style_weight),
     learning_rate='%g'%(opts.learning_rate),
@@ -204,7 +205,8 @@ def printProgress(iteration, total, prefix='', suffix='', decimals=1, barLength=
     percent = formatStr.format(100 * (iteration / float(total)))
     filledLength = int(round(barLength * iteration / float(total)))
     bar = '█' * filledLength + '-' * (barLength - filledLength)
-    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar, percent, '%', suffix)),
+    text = '\r%s |%s| %s%s %s' % (prefix, bar, percent, '%', suffix)
+    sys.stdout.write(text.encode('utf-8')),
     if iteration == total:
         sys.stdout.write('\n')
     sys.stdout.flush()

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -128,8 +128,7 @@ def build_parser():
 
 
 def run_on_file(opts, input_file):
-    output_dir = expanduser(opts.output_path) if opts.output_path is not None
-    else os.getcwd()
+    output_dir = expanduser(opts.output_path) if opts.output_path is not None else os.getcwd()
     if opts.style_as_folder is True:
         output_dir = join(output_dir, splitext(basename(opts.style_image))[0])
     if opts.input_file_as_folder is True:

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import os, sys, subprocess
+import os
+import sys
+import subprocess
 from datetime import datetime
 from argparse import ArgumentParser
 from os.path import basename, splitext, expanduser, isfile, join
@@ -9,6 +11,7 @@ from os import listdir
 RUN_SCRIPT_NAME = "neural_style.lua"
 DEF_CONTENT_LAYERS = 'relu4_2'
 DEF_STYLE_LAYERS = 'relu1_1,relu2_1,relu3_1,relu4_1,relu5_1'
+
 
 def build_parser():
     parser = ArgumentParser()
@@ -125,26 +128,27 @@ def build_parser():
 
 
 def run_on_file(opts, input_file):
-    output_dir = expanduser(opts.output_path) if opts.output_path != None else os.getcwd()
-    if opts.style_as_folder == True:
+    output_dir = expanduser(opts.output_path) if opts.output_path is not None
+    else os.getcwd()
+    if opts.style_as_folder is True:
         output_dir = join(output_dir, splitext(basename(opts.style_image))[0])
-    if opts.input_file_as_folder == True:
+    if opts.input_file_as_folder is True:
         output_dir = join(output_dir, splitext(basename(input_file))[0])
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     optimizer_str = opts.optimizer
     if opts.optimizer == 'adam':
-        optimizer_str += '_lr{0}'.format('%g'%(opts.learning_rate))
+        optimizer_str += '_lr{0}'.format('%g' % (opts.learning_rate))
     out_file_name = '{style_image}{content_image}{sep1}i{iter}cw{content_weight}_sw{style_weight}_\
 {optimizer}_sc{style_scale}_tv{tv_weight}'.format(
-    style_image=splitext(basename(opts.style_image))[0] if opts.style_as_folder == False else '',
-    content_image=('_'+splitext(basename(input_file))[0]) if opts.input_file_as_folder == False else '',
-    sep1='_' if opts.input_file_as_folder == False and opts.style_as_folder == False else '',
+    style_image=splitext(basename(opts.style_image))[0] if opts.style_as_folder is False else '',
+    content_image=('_'+splitext(basename(input_file))[0]) if opts.input_file_as_folder is False else '',
+    sep1='_' if opts.input_file_as_folder is False and opts.style_as_folder is False else '',
     iter=opts.num_iter,
-    content_weight='%g'%(opts.content_weight),
-    style_weight='%g'%(opts.style_weight),
+    content_weight='%g' % (opts.content_weight),
+    style_weight='%g' % (opts.style_weight),
     optimizer=optimizer_str,
-    style_scale='%g'%(opts.style_scale),
+    style_scale='%g' % (opts.style_scale),
     tv_weight=opts.tv_weight
     )
     if opts.normalize_gradients:
@@ -182,32 +186,32 @@ def run_on_file(opts, input_file):
 -learning_rate {learning_rate} \
 -original_colors {original_colors} {cudnn_autotune} \
 -pooling {pooling} -proto_file {proto_file} -model_file {model_file}'.format(
-    script=RUN_SCRIPT_NAME,
-    style_scale=opts.style_scale,
-    init=opts.init,
-    style_image=expanduser(opts.style_image),
-    content_image=input_file,
-    image_size=opts.image_size,
-    output_image=out_file_path,
-    content_weight=opts.content_weight,
-    style_weight=opts.style_weight,
-    save_iter=opts.save_iter,
-    print_iter=opts.print_iter,
-    num_iterations=opts.num_iter,
-    content_layers=opts.content_layers,
-    style_layers=opts.style_layers,
-    gpu=opts.gpu,
-    optimizer=opts.optimizer,
-    tv_weight=opts.tv_weight,
-    backend=opts.backend,
-    seed=opts.seed,
-    normalize_gradients=('-normalize_gradients' if opts.normalize_gradients else ''),
-    learning_rate=opts.learning_rate,
-    original_colors=('1' if opts.original_colors else '0'),
-    cudnn_autotune=('-cudnn_autotune' if opts.cudnn_autotune else ''),
-    pooling=opts.pooling,
-    proto_file=opts.proto_file,
-    model_file=opts.model_file)
+                script=RUN_SCRIPT_NAME,
+                style_scale=opts.style_scale,
+                init=opts.init,
+                style_image=expanduser(opts.style_image),
+                content_image=input_file,
+                image_size=opts.image_size,
+                output_image=out_file_path,
+                content_weight=opts.content_weight,
+                style_weight=opts.style_weight,
+                save_iter=opts.save_iter,
+                print_iter=opts.print_iter,
+                num_iterations=opts.num_iter,
+                content_layers=opts.content_layers,
+                style_layers=opts.style_layers,
+                gpu=opts.gpu,
+                optimizer=opts.optimizer,
+                tv_weight=opts.tv_weight,
+                backend=opts.backend,
+                seed=opts.seed,
+                normalize_gradients=('-normalize_gradients' if opts.normalize_gradients else ''),
+                learning_rate=opts.learning_rate,
+                original_colors=('1' if opts.original_colors else '0'),
+                cudnn_autotune=('-cudnn_autotune' if opts.cudnn_autotune else ''),
+                pooling=opts.pooling,
+                proto_file=opts.proto_file,
+                model_file=opts.model_file)
 
     print('Script \'{0}\''.format(run_script))
     with subprocess.Popen(run_script, shell=True,
@@ -220,7 +224,8 @@ def run_on_file(opts, input_file):
 
 
 # Print iterations progress
-def printProgress(iteration, total, prefix='', suffix='', decimals=1, barLength=100):
+def printProgress(iteration, total, prefix='', suffix='', decimals=1,
+                  barLength=100):
     """
     Call in a loop to create terminal progress bar
     @params:

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -215,8 +215,8 @@ def run_on_file(opts, input_file):
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
                           universal_newlines=True) as proc:
-        print(proc.stdout.read())
-        print(proc.stderr.read())
+        for line in iter(proc.stdout.readline, ''):
+            sys.stdout.write(line)
 
 
 # Print iterations progress

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -135,11 +135,12 @@ def run_on_file(opts, input_file):
     optimizer_str = opts.optimizer
     if opts.optimizer == 'adam':
         optimizer_str += '_lr{0}'.format('%g'%(opts.learning_rate))
-    out_file_name = '{style_image}{content_image}{sep1}cw{content_weight}_sw{style_weight}_\
+    out_file_name = '{style_image}{content_image}{sep1}i{iter}cw{content_weight}_sw{style_weight}_\
 {optimizer}_sc{style_scale}_tv{tv_weight}'.format(
     style_image=splitext(basename(opts.style_image))[0] if opts.style_as_folder == False else '',
     content_image=('_'+splitext(basename(input_file))[0]) if opts.input_file_as_folder == False else '',
     sep1='_' if opts.input_file_as_folder == False and opts.style_as_folder == False else '',
+    iter=opts.num_iter,
     content_weight='%g'%(opts.content_weight),
     style_weight='%g'%(opts.style_weight),
     optimizer=optimizer_str,

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -107,7 +107,7 @@ def build_parser():
                         default=False,
                         dest='time_markers')
 
-    # TODO: style_layer_weights
+    # TODO: style_layer_weights, lbfgs_num_correction
 
     return parser
 
@@ -116,13 +116,16 @@ def run_on_file(opts, input_file):
     output_dir = expanduser(opts.output_path) if opts.output_path != None else os.getcwd()
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
+    optimizer_str = opts.optimizer
+    if opts.optimizer == 'adam':
+        optimizer_str += '_lr{0}'.format('%g'%(opts.learning_rate))
     out_file_name = '{style_image}_{content_image}_cw{content_weight}_sw{style_weight}_\
-lr{learning_rate}_sc{style_scale}_tv{tv_weight}'.format(
+{optimizer}_sc{style_scale}_tv{tv_weight}'.format(
     style_image=splitext(basename(opts.style_image))[0],
     content_image=splitext(basename(input_file))[0],
     content_weight='%g'%(opts.content_weight),
     style_weight='%g'%(opts.style_weight),
-    learning_rate='%g'%(opts.learning_rate),
+    optimizer=optimizer_str,
     style_scale='%g'%(opts.style_scale),
     tv_weight=opts.tv_weight
     )

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -204,8 +204,8 @@ def printProgress(iteration, total, prefix='', suffix='', decimals=1, barLength=
     formatStr = "{0:." + str(decimals) + "f}"
     percent = formatStr.format(100 * (iteration / float(total)))
     filledLength = int(round(barLength * iteration / float(total)))
-    bar = '█' * filledLength + '-' * (barLength - filledLength)
-    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar, percent, '%', suffix)),
+    bar_str = '█' * filledLength + '-' * (barLength - filledLength)
+    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar_str, percent, '%', suffix)),
     if iteration == total:
         sys.stdout.write('\n')
     sys.stdout.flush()
@@ -217,6 +217,7 @@ def main():
     # check_opts(opts)
 
     input_path = expanduser(opts.content_image)
+    print('Input path is {0}'.format(input_path))
     if os.path.isfile(input_path):
         run_on_file(opts, input_path)
     else:
@@ -224,6 +225,7 @@ def main():
         count = len(input_files)
         i = 1
         for input_filename in input_files:
+            print('Input file is {0}'.format(input_filename))
             run_on_file(opts, input_filename)
             printProgress(i, count, prefix='Progress:',
                           suffix='Complete', barLength=100)

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -113,7 +113,7 @@ def build_parser():
 
 
 def run_on_file(opts, input_file):
-    output_dir = opts.output_path if opts.output_path != None else os.getcwd()
+    output_dir = expanduser(opts.output_path) if opts.output_path != None else os.getcwd()
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     out_file_name = '{style_image}_{content_image}_cw{content_weight}_sw{style_weight}_\

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -1,6 +1,12 @@
-import sys
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import os
+import subprocess
+from datetime import datetime
 from argparse import ArgumentParser
+from os.path import basename, splitext
 
+RUN_SCRIPT_NAME = "neural_style.lua"
 
 def build_parser():
     parser = ArgumentParser()
@@ -10,11 +16,11 @@ def build_parser():
                         dest='style_image',
                         help='Style target image',
                         metavar='STYLE_IMAGE', required=True)
-
+    '''
     parser.add_argument('-style_blend_weights', type=str,
                         default=None,
                         dest='style_blend_weights')
-
+    '''
     parser.add_argument('-content_image', type=str,
                         default='examples/inputs/tubingen.jpg',
                         dest='content_image', help='Content target image',
@@ -31,13 +37,13 @@ def build_parser():
                         help='Zero-indexed ID of the GPU to use; for \
                         CPU mode set -gpu = -1',
                         metavar='GPU')
-
+    '''
     parser.add_argument('-multigpu_strategy', type=str, default='',
                         dest='multigpu_strategy',
                         help='Index of layers to split the network\
                         across GPUs',
                         metavar='MULTI_GPU')
-
+    '''
     # Optimization options
     parser.add_argument('-content_weight', default=5, type=float,
                         dest='content_weight')
@@ -48,7 +54,7 @@ def build_parser():
     parser.add_argument('-num_iterations', default=1000, type=float,
                         dest='num_iter')
     parser.add_argument('-normalize_gradients', default=False,
-                        dest='norm_gradients')
+                        dest='normalize_gradients')
     parser.add_argument('-init', default='random', dest='init_image',
                         choices=['random', 'image'])
     parser.add_argument('-optimizer', default='lbfgs', dest='optimizer',
@@ -57,14 +63,12 @@ def build_parser():
                         dest='learning_rate')
 
     # Output options
-    parser.add_argument('-learning_rate', default=5, type=int,
-                        dest='learning_rate')
     parser.add_argument('-print_iter', default=50, type=int,
                         dest='print_iter')
     parser.add_argument('-save_iter', default=100, type=int,
                         dest='save_iter')
-    parser.add_argument('-output_image', default='out.jpg', type=str,
-                        dest='output_image')
+    parser.add_argument('-output_path', default=None, type=str,
+                        dest='output_path')
 
     # Other options
     parser.add_argument('-style_scale', default=1.0, type=float,
@@ -95,6 +99,12 @@ def build_parser():
                         help='layers for style',
                         default='relu1_1,relu2_1,relu3_1,relu4_1,relu5_1',
                         dest='style_layers')
+
+    # Runner options
+    parser.add_argument('-time_markers',
+                        default=False,
+                        dest='time_markers')
+
     # TODO: style_layer_weights
 
     return parser
@@ -107,6 +117,81 @@ def main():
     parser = build_parser()
     opts = parser.parse_args()
     # check_opts(opts)
+
+    output_dir = opts.output_path if opts.output_path != None else os.getcwd()
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    out_file_name = '{style_image}_{content_image}_cw{content_weight}_sw{style_weight}_\
+lr{learning_rate}_sc{style_scale}_tv{tv_weight}'.format(
+    style_image=splitext(basename(opts.style_image))[0],
+    content_image=splitext(basename(opts.content_image))[0],
+    content_weight='%g'%(opts.content_weight),
+    style_weight='%g'%(opts.style_weight),
+    learning_rate='%g'%(opts.learning_rate),
+    style_scale='%g'%(opts.style_scale),
+    tv_weight=opts.tv_weight
+    )
+    if opts.normalize_gradients:
+        out_file_name += '_norm'
+    if opts.original_colors:
+        out_file_name += '_colors'
+    if opts.time_markers:
+        now = datetime.now()
+        out_file_name += '_{0}'.format(now.strftime('%Y%m%d_%H%M%S'))
+    out_file_name += '.jpg'
+    out_file_path = os.path.join(output_dir, out_file_name)
+
+    run_script = 'th {script} -style_scale {style_scale} \
+-init {init} -style_image "{style_image}" \
+-content_image "{content_image}" -image_size {image_size} \
+-output_image "{output_image}" \
+-content_weight {content_weight} -style_weight {style_weight} \
+-save_iter {save_iter} \
+-print_iter {print_iter} \
+-num_iterations {num_iterations} -content_layers {content_layers} \
+-style_layers {style_layers} \
+-gpu {gpu} -optimizer {optimizer} -tv_weight {tv_weight} \
+-backend {backend} \
+-seed {seed} {normalize_gradients} \
+-learning_rate {learning_rate} \
+-original_colors {original_colors} {cudnn_autotune} \
+-pooling {pooling} -proto_file {proto_file} -model_file {model_file}'.format(
+    script=RUN_SCRIPT_NAME,
+    style_scale=opts.style_scale,
+    init=opts.init_image,
+    style_image=opts.style_image,
+    content_image=opts.content_image,
+    image_size=opts.image_size,
+    output_image=out_file_path,
+    content_weight=opts.content_weight,
+    style_weight=opts.style_weight,
+    save_iter=opts.save_iter,
+    print_iter=opts.print_iter,
+    num_iterations=opts.num_iter,
+    content_layers=opts.content_layers,
+    style_layers=opts.style_layers,
+    gpu=opts.gpu,
+    optimizer=opts.optimizer,
+    tv_weight=opts.tv_weight,
+    backend=opts.backend,
+    seed=opts.seed,
+    normalize_gradients=('-normalize_gradients' if opts.normalize_gradients else ''),
+    learning_rate=opts.learning_rate,
+    original_colors=('1' if opts.original_colors else '0'),
+    cudnn_autotune=('-cudnn_autotune' if opts.cudnn_autotune else ''),
+    pooling=opts.pooling,
+    proto_file=opts.proto_file,
+    model_file=opts.model_file)
+
+    print('Script \'{0}\''.format(run_script))
+
+    with subprocess.Popen(run_script, shell=True,
+                          stdin=subprocess.PIPE,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          universal_newlines=True) as proc:
+        print(proc.stdout.read())
+        print(proc.stderr.read())
 
 if __name__ == '__main__':
     main()

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -209,7 +209,6 @@ def run_on_file(opts, input_file):
     model_file=opts.model_file)
 
     print('Script \'{0}\''.format(run_script))
-    return
     with subprocess.Popen(run_script, shell=True,
                           stdin=subprocess.PIPE,
                           stdout=subprocess.PIPE,

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -1,0 +1,112 @@
+import sys
+from argparse import ArgumentParser
+
+
+def build_parser():
+    parser = ArgumentParser()
+    # Basic options
+    parser.add_argument('-style_image', type=str,
+                        default='examples/inputs/seated-nude.jpg',
+                        dest='style_image',
+                        help='Style target image',
+                        metavar='STYLE_IMAGE', required=True)
+
+    parser.add_argument('-style_blend_weights', type=str,
+                        default=None,
+                        dest='style_blend_weights')
+
+    parser.add_argument('-content_image', type=str,
+                        default='examples/inputs/tubingen.jpg',
+                        dest='content_image', help='Content target image',
+                        metavar='CONTENT_IMAGE', required=True)
+
+    parser.add_argument('-image_size', type=int,
+                        default=512,
+                        dest='image_size',
+                        help='Maximum height / width of generated image',
+                        metavar='IMAGE_SIZE')
+
+    parser.add_argument('-gpu', default=0, type=int,
+                        dest='gpu',
+                        help='Zero-indexed ID of the GPU to use; for \
+                        CPU mode set -gpu = -1',
+                        metavar='GPU')
+
+    parser.add_argument('-multigpu_strategy', type=str, default='',
+                        dest='multigpu_strategy',
+                        help='Index of layers to split the network\
+                        across GPUs',
+                        metavar='MULTI_GPU')
+
+    # Optimization options
+    parser.add_argument('-content_weight', default=5, type=float,
+                        dest='content_weight')
+    parser.add_argument('-style_weight', default=100, type=float,
+                        dest='style_weight')
+    parser.add_argument('-tv_weight', default=0.0003, type=float,
+                        dest='tv_weight')
+    parser.add_argument('-num_iterations', default=1000, type=float,
+                        dest='num_iter')
+    parser.add_argument('-normalize_gradients', default=False,
+                        dest='norm_gradients')
+    parser.add_argument('-init', default='random', dest='init_image',
+                        choices=['random', 'image'])
+    parser.add_argument('-optimizer', default='lbfgs', dest='optimizer',
+                        choices=['lbfgs', 'adam'])
+    parser.add_argument('-learning_rate', default=5, type=float,
+                        dest='learning_rate')
+
+    # Output options
+    parser.add_argument('-learning_rate', default=5, type=int,
+                        dest='learning_rate')
+    parser.add_argument('-print_iter', default=50, type=int,
+                        dest='print_iter')
+    parser.add_argument('-save_iter', default=100, type=int,
+                        dest='save_iter')
+    parser.add_argument('-output_image', default='out.jpg', type=str,
+                        dest='output_image')
+
+    # Other options
+    parser.add_argument('-style_scale', default=1.0, type=float,
+                        dest='style_scale')
+    parser.add_argument('-original_colors', default=False,
+                        dest='original_colors')
+    parser.add_argument('-pooling', default='max',
+                        choices=['max', 'avg'])
+    parser.add_argument('-proto_file', type=str,
+                        default='models/VGG_ILSVRC_19_layers_deploy.prototxt',
+                        dest='proto_file')
+    parser.add_argument('-model_file', type=str,
+                        default='models/VGG_ILSVRC_19_layers.caffemodel',
+                        dest='model_file')
+    parser.add_argument('-backend', default='nn',
+                        choices=['nn', 'cudnn', 'clnn'])
+    parser.add_argument('-cudnn_autotune', default=False,
+                        dest='cudnn_autotune')
+    parser.add_argument('-seed', default=-1, type=int,
+                        dest='seed')
+
+    # Layers options
+    parser.add_argument('-content_layers', type=str,
+                        help='layers for content',
+                        default='relu4_2',
+                        dest='content_layers')
+    parser.add_argument('-style_layers', type=str,
+                        help='layers for style',
+                        default='relu1_1,relu2_1,relu3_1,relu4_1,relu5_1',
+                        dest='style_layers')
+    # TODO: style_layer_weights
+
+    return parser
+
+
+# def check_opts(opts):
+
+
+def main():
+    parser = build_parser()
+    opts = parser.parse_args()
+    # check_opts(opts)
+
+if __name__ == '__main__':
+    main()

--- a/run_neural_style.py
+++ b/run_neural_style.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
+from __future__ import print_function
 import os, sys, subprocess
 from datetime import datetime
 from argparse import ArgumentParser
@@ -204,8 +203,8 @@ def printProgress(iteration, total, prefix='', suffix='', decimals=1, barLength=
     formatStr = "{0:." + str(decimals) + "f}"
     percent = formatStr.format(100 * (iteration / float(total)))
     filledLength = int(round(barLength * iteration / float(total)))
-    bar_str = '█' * filledLength + '-' * (barLength - filledLength)
-    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar_str, percent, '%', suffix)),
+    bar = '█' * filledLength + '-' * (barLength - filledLength)
+    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar, percent, '%', suffix)),
     if iteration == total:
         sys.stdout.write('\n')
     sys.stdout.flush()


### PR DESCRIPTION
I've created a helper Python (tested on 3.5.2) script run_neural_style.py to automate output file path and name generation. 

`python3 run_neural_style.py -style_image styles/style22_750.jpg -content_image input/sample1.jpg -optimizer adam -init image -output_path output -backend cudnn -style_weight 800 -content_weight 200 -style_scale 1.8 -learning_rate 3 -image_size 300 -tv_weight 0.001 -seed 150 -num_iterations 500` will create a `output/style22_750/sample1` folder and the result file name will be `i500.0cw200_sw600_adam_lr3_sc1.8_tv0.001.jpg`

The command-line arguments are similar to the original ones, I've documented the difference in the readme. 

Unfortunately, my fork initially was merged with the `style_layer_weights` PR, but that's not a destructive change, so I don't think it's a problem.

There are too many commits in my brach with small fixes, so if you want to merge my changes, I'd recommend to merge them as one commit.


