### PR TITLE
Flexible gradients normalization

### DIFF
--- a/match_colors.lua
+++ b/match_colors.lua
@@ -1,0 +1,86 @@
+-- Based on Leon Gatys's work "Controlling Perceptual Factors in Neural Style Transfer":
+-- https://arxiv.org/abs/1611.07865
+-- his code:
+-- https://github.com/leongatys/NeuralImageSynthesis/blob/master/ExampleNotebooks/ColourControl.ipynb
+-- and on ProGamerGov's issue and code:
+-- https://github.com/jcjohnson/neural-style/issues/376
+
+require 'torch'
+require 'image'
+
+local cmd = torch.CmdLine()
+cmd:text()
+cmd:text('Coloring style image to content palette.')
+cmd:text()
+cmd:option('-content_image', 'examples/inputs/tubingen.jpg',
+           'Content source image')
+cmd:option('-style_image', 'examples/inputs/seated-nude.jpg',
+           'Style target image')
+cmd:option('-color_function', 'pca',
+           'Color matching function: pca, chol, sym')
+cmd:option('-output_image', 'out.png')
+cmd:text()
+
+
+local function main(params)
+  local content_img = image.load(params.content_image, 3)
+  local style_img = image.load(params.style_image, 3)
+
+  local output_img = match_color(style_img, content_img, params.color_function)
+  image.save(params.output_image, output_img)
+end
+
+
+function match_color(target_img, source_img, mode, eps)
+  -- Matches the colour distribution of the target image to that of the source image
+  -- using a linear transform.
+  -- Images are expected to be of form (c,w,h) and float in [0,1].
+  -- Modes are chol, pca or sym for different choices of basis.
+
+  mode = mode or 'pca'
+  eps = eps or 1e-5
+  local eyem = torch.eye(source_img:size(1)):mul(eps)
+
+  local mu_s = torch.mean(source_img, 3):mean(2)
+  local s = source_img - mu_s:expandAs(source_img)
+  s = s:view(s:size(1), s[1]:nElement())
+  local Cs = s * s:t() / s:size(2) + eyem
+
+  local mu_t = torch.mean(target_img, 3):mean(2)
+  local t = target_img - mu_t:expandAs(target_img)
+  t = t:view(t:size(1), t[1]:nElement())
+  local Ct = t * t:t() / t:size(2) + eyem
+
+  local ts
+  if mode == 'chol' then
+    local chol_s = torch.potrf(Cs):t()
+    local chol_t = torch.potrf(Ct):t()
+    ts = chol_s * torch.inverse(chol_t) * t
+  elseif mode == 'pca' then
+    local eva_t, eve_t = torch.symeig(Ct, 'V', 'L')
+    local Qt = eve_t * torch.diag(eva_t):sqrt() * eve_t:t()
+    local eva_s, eve_s = torch.symeig(Cs, 'V', 'L')
+    local Qs = eve_s * torch.diag(eva_s):sqrt() * eve_s:t()
+    ts = Qs * torch.inverse(Qt) * t
+  elseif mode == 'sym' then
+    local eva_t, eve_t = torch.symeig(Ct, 'V', 'L')
+    local Qt = eve_t * torch.diag(eva_t):sqrt() * eve_t:t()
+    local Qt_Cs_Qt = Qt * Cs * Qt
+    local eva_QtCsQt, eve_QtCsQt = torch.symeig(Qt_Cs_Qt, 'V', 'L')
+    local QtCsQt = eve_QtCsQt * torch.diag(eva_QtCsQt):sqrt() * eve_QtCsQt:t()
+    ts = torch.inverse(Qt) * QtCsQt * torch.inverse(Qt) * t
+  else
+    assert((mode == 'chol' or
+            mode == 'pca' or
+            mode == 'sym'),
+            'Unknown color matching mode. Stop.')
+  end
+
+  local matched_img = ts:viewAs(target_img) + mu_s:expandAs(target_img)
+  -- matched_img = image.minmax{tensor=matched_img, min=0, max=1}
+  return matched_img:clamp(0, 1)
+end
+
+
+local params = cmd:parse(arg)
+main(params)

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -561,8 +561,8 @@ function StyleLoss:updateGradInput(input, gradOutput)
     local dG = self.crit:backward(self.G, self.target)
     dG:div(input:nElement())
     self.gradInput = self.gram:backward(input, dG)
-    if self.normalize ~= 0.0 then
-      if (self.normalize == 1.0) and (content_ignition == false) then
+    if (self.normalize ~= 0.0) and (content_ignition == false) then
+      if self.normalize == 1.0 then
         self.gradInput:div(torch.norm(self.gradInput, 1) + 1e-8)
       else
         self.gradInput:div(torch.norm(self.gradInput, 1) ^ self.normalize + 1e-8)


### PR DESCRIPTION
Since results with regular and normalized gradients are quite different, maybe it would be useful to apply floating point normalization factor instead of boolean "on/off" option.

Difference – smooth choice between ordinary and normalized gradients _(above are the old option values, below are the new ones)_:

![flexible_gradients_normalization_full_range](https://cloud.githubusercontent.com/assets/679731/23592120/121688e8-020d-11e7-950b-be6d6a159a57.jpg)

**Disadvantages**: new syntax is incompatible with old option (need to use "-normalize_gradients **1.0**").
 
New "normalize_gradients" value "0.0" (or skipped option) corresponds to old value "false" (normalization skipped completely), and new value "1.0" corresponds to old value "true" (old code is used unchanged).

***Update**: added normalization auto-disabling when content losses are low – it helps to begin stylization faster.
With this, option values above 1.0 always make noisy garbage, therefore its range _should_ be limited to 1.