### PR TITLE
Added a reflectance padding option from leongatys/NeuralImageSynthesis

### DIFF
--- a/neural_style.lua
+++ b/neural_style.lua
@@ -56,7 +56,6 @@ local function main(params)
   local loadcaffe_backend = params.backend
   if params.backend == 'clnn' then loadcaffe_backend = 'nn' end
   local cnn = loadcaffe.load(params.proto_file, params.model_file, loadcaffe_backend):type(dtype)
-  cnn = set_datatype(cnn, params.gpu)
 
   local content_image = image.load(params.content_image, 3)
   content_image = image.scale(content_image, params.image_size, 'bilinear')

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -56,6 +56,7 @@ local function main(params)
   local loadcaffe_backend = params.backend
   if params.backend == 'clnn' then loadcaffe_backend = 'nn' end
   local cnn = loadcaffe.load(params.proto_file, params.model_file, loadcaffe_backend):type(dtype)
+  cnn = set_datatype(cnn, params.gpu)
 
   local content_image = image.load(params.content_image, 3)
   content_image = image.scale(content_image, params.image_size, 'bilinear')

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -48,6 +48,7 @@ cmd:option('-seed', -1)
 cmd:option('-content_layers', 'relu4_2', 'layers for content')
 cmd:option('-style_layers', 'relu1_1,relu2_1,relu3_1,relu4_1,relu5_1', 'layers for style')
 
+cmd:option('-reflectance', false, 'if true, use reflectance padding')
 
 local function main(params)
   local dtype, multigpu = setup_gpu(params)
@@ -129,6 +130,14 @@ local function main(params)
       else
         net:add(layer)
       end
+      if is_convolution and params.reflectance then
+                    local padW, padH = layer.padW, layer.padH
+                    local pad_layer = nn.SpatialReflectionPadding(padW, padW, padH, padH)
+                    pad_layer = set_datatype(pad_layer, params.gpu)
+                    net:add(pad_layer)
+                    layer.padW = 0
+                    layer.padH = 0
+      end                           
       if name == content_layers[next_content_idx] then
         print("Setting up content layer", i, ":", layer.name)
         local norm = params.normalize_gradients

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -130,7 +130,8 @@ local function main(params)
       else
         net:add(layer)
       end
-      --reflectance padding option from leongatys/NeuralImageSynthesis     
+      --reflectance padding option from leongatys/NeuralImageSynthesis
+      local is_convolution = (layer_type == 'cudnn.SpatialConvolution' or layer_type == 'nn.SpatialConvolution')   
       if is_convolution and params.reflectance then
                     local padW, padH = layer.padW, layer.padH
                     local pad_layer = nn.SpatialReflectionPadding(padW, padW, padH, padH)
@@ -605,6 +606,17 @@ function TVLoss:updateGradInput(input, gradOutput)
   self.gradInput:add(gradOutput)
   return self.gradInput
 end
+
+-- Function to set gpu/cpu datatype
+function set_datatype(data, gpu)
+    if gpu >= 0 then
+        data = data:cuda()
+    else
+        data = data:double()
+    end
+    return data
+end
+
 
 
 local params = cmd:parse(arg)

--- a/neural_style.lua
+++ b/neural_style.lua
@@ -130,6 +130,7 @@ local function main(params)
       else
         net:add(layer)
       end
+      --reflectance padding option from leongatys/NeuralImageSynthesis     
       if is_convolution and params.reflectance then
                     local padW, padH = layer.padW, layer.padH
                     local pad_layer = nn.SpatialReflectionPadding(padW, padW, padH, padH)


### PR DESCRIPTION
The new command is used similar to the `-normalize_gradients` command, with:  `-reflectance`. By default, it is set to `false`.

The related issue can be found here: https://github.com/jcjohnson/neural-style/issues/376