### PR TITLE
Initialize random numbers generator at start

### DIFF
--- a/neural_style.lua
+++ b/neural_style.lua
@@ -50,6 +50,9 @@ cmd:option('-style_layers', 'relu1_1,relu2_1,relu3_1,relu4_1,relu5_1', 'layers f
 
 
 local function main(params)
+  if params.seed >= 0 then
+    torch.manualSeed(params.seed)
+  end
   local dtype, multigpu = setup_gpu(params)
 
   local loadcaffe_backend = params.backend
@@ -195,9 +198,6 @@ local function main(params)
   collectgarbage()
 
   -- Initialize the image
-  if params.seed >= 0 then
-    torch.manualSeed(params.seed)
-  end
   local img = nil
   if params.init == 'random' then
     img = torch.randn(content_image:size()):float():mul(0.001)


### PR DESCRIPTION
When model is being loaded / rebuild, Torch's random numbers generator is not yet initialized with manual seed, which makes _always_ random images with NIN ImageNet model, even with "`-seed`" option.

Because [NIN ImageNet model](https://github.com/BVLC/caffe/wiki/Model-Zoo#network-in-network-model) uses [dropout layer](https://github.com/torch/nn/blob/master/doc/simple.md#dropout) with random values.

Placing RNG initialization at start allows repeatable results (with manual seed) with NIN ImageNet model, like with VGG models.