### PR TITLE
Fixed misformatted Markdown h1 title

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-#neural-style Installation
+# Neural-style Installation
 
 This guide will walk you through the setup for `neural-style` on Ubuntu.
 


### PR DESCRIPTION
Very simple commit. Markdown requires there to be a space between the pound signs/hashes and the heading, and omitting the space would result in the headings not rendering properly. I fixed this one for you.